### PR TITLE
fix: `done` not passed to processors

### DIFF
--- a/lib/providers/agenda.explorer.ts
+++ b/lib/providers/agenda.explorer.ts
@@ -65,6 +65,7 @@ export class AgendaExplorer implements OnModuleInit {
                 jobProcessor,
                 jobOptions,
                 jobProcessorType,
+                methodRef.length,
               );
             } else if (this.metadataAccessor.isEventListener(methodRef)) {
               const listener = this.wrapFunctionInTryCatchBlocks(

--- a/lib/providers/agenda.orchestrator.ts
+++ b/lib/providers/agenda.orchestrator.ts
@@ -5,7 +5,7 @@ import {
   OnApplicationShutdown,
 } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import Agenda, { AgendaConfig, Processor } from 'agenda';
+import Agenda, { AgendaConfig, Job, Processor } from 'agenda';
 import { Db } from 'mongodb';
 import { NO_QUEUE_FOUND } from '../agenda.messages';
 import { DATABASE_CONNECTION } from '../constants';
@@ -20,6 +20,7 @@ type JobProcessorConfig = {
   handler: Processor;
   type: JobProcessorType;
   options: RepeatableJobOptions | NonRepeatableJobOptions;
+  useCallback: boolean;
 };
 
 export type EventListener = (...args: any[]) => void;
@@ -50,9 +51,15 @@ export class AgendaOrchestrator
   private defineJobProcessors(agenda: Agenda, registry: QueueRegistry) {
     registry.processors.forEach(
       (jobConfig: JobProcessorConfig, jobName: string) => {
-        const { options, handler } = jobConfig;
+        const { options, handler, useCallback } = jobConfig;
 
-        agenda.define(jobName, options, handler);
+        if (useCallback) {
+          agenda.define(jobName, options, (job: Job, done: () => void) =>
+            handler(job, done),
+          );
+        } else {
+          agenda.define(jobName, options, handler);
+        }
       },
     );
   }
@@ -150,11 +157,13 @@ export class AgendaOrchestrator
     processor: Processor & Record<'_name', string>,
     options: AgendaModuleJobOptions,
     type: JobProcessorType,
+    useCallback: boolean,
   ) {
     const jobName = options.name || processor._name;
 
     this.queues.get(queueToken)?.processors.set(jobName, {
       handler: processor,
+      useCallback,
       type,
       options,
     });


### PR DESCRIPTION
agenda [uses the job processor's argument length](https://github.com/agenda/agenda/blob/master/lib/job/run.ts#L104) to determine whether or not the processor should be invoked with the `jobCallback` argument.

Currently, the processor's argument length is lost when [wrapping the method ref](https://github.com/jongolden/agenda-nest/blob/main/lib/providers/agenda.explorer.ts#L92). In order to preserve agenda's callback behavior, we need to check the method ref's original arg length and use it to determine whether or not the processor should receive a callback arg.

If the processor does require a callback arg, we will wrap the processor in an anonymous function that also requires a callback.

Fixes #8