### PR TITLE
feat: support asynchronous queue registration

### DIFF
--- a/examples/multiple-queues/.env
+++ b/examples/multiple-queues/.env
@@ -1,0 +1,2 @@
+NODE_ENV=development
+AUTO_START_QUEUE=true

--- a/examples/multiple-queues/package-lock.json
+++ b/examples/multiple-queues/package-lock.json
@@ -10,9 +10,10 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^8.0.0",
+        "@nestjs/config": "^2.3.1",
         "@nestjs/core": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
-        "agenda-nest": "file:../../agenda-nest-1.0.1.tgz",
+        "agenda-nest": "file:../../agenda-nest-1.2.1.tgz",
         "mongodb": "^4.7.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
@@ -1451,6 +1452,30 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.3.1.tgz",
+      "integrity": "sha512-Ckzel0NZ9CWhNsLfE1hxfDuxJuEbhQvGxSlmZ1/X8awjRmAA/g3kT6M1+MO1SHj1wMtPyUfd9WpwkiqFbiwQgA==",
+      "dependencies": {
+        "dotenv": "16.0.3",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.0.0 || ^7.2.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.4.7.tgz",
@@ -2441,13 +2466,13 @@
       }
     },
     "node_modules/agenda-nest": {
-      "version": "1.0.1",
-      "resolved": "file:../../agenda-nest-1.0.1.tgz",
-      "integrity": "sha512-U0JSATL7+cxMrDr5tzXHOkKOXO0UVMJy4IgJ675t6cLUVc6a8dVrckyqzLIY1WkcLoNkpketiO3Wu7/mRX6DHw==",
+      "version": "1.2.1",
+      "resolved": "file:../../agenda-nest-1.2.1.tgz",
+      "integrity": "sha512-6cMCaWn78kYGm8H8d3wuZE/MuH1vgGEflEvb3S4nVIDxWdQtuizUnD2nZjIqC3lkyK032CytIHWOtrFyfqeFTw==",
       "license": "MIT",
       "peerDependencies": {
-        "@nestjs/common": "8.x",
-        "@nestjs/core": "8.x",
+        "@nestjs/common": "8.x || 9.x",
+        "@nestjs/core": "8.x || 9.x",
         "agenda": "4.x"
       }
     },
@@ -3589,6 +3614,22 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -6293,8 +6334,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -10113,6 +10153,24 @@
         "uuid": "8.3.2"
       }
     },
+    "@nestjs/config": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.3.1.tgz",
+      "integrity": "sha512-Ckzel0NZ9CWhNsLfE1hxfDuxJuEbhQvGxSlmZ1/X8awjRmAA/g3kT6M1+MO1SHj1wMtPyUfd9WpwkiqFbiwQgA==",
+      "requires": {
+        "dotenv": "16.0.3",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
+      }
+    },
     "@nestjs/core": {
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.4.7.tgz",
@@ -10896,8 +10954,8 @@
       }
     },
     "agenda-nest": {
-      "version": "file:../../agenda-nest-1.0.1.tgz",
-      "integrity": "sha512-U0JSATL7+cxMrDr5tzXHOkKOXO0UVMJy4IgJ675t6cLUVc6a8dVrckyqzLIY1WkcLoNkpketiO3Wu7/mRX6DHw==",
+      "version": "file:../../agenda-nest-1.2.1.tgz",
+      "integrity": "sha512-6cMCaWn78kYGm8H8d3wuZE/MuH1vgGEflEvb3S4nVIDxWdQtuizUnD2nZjIqC3lkyK032CytIHWOtrFyfqeFTw==",
       "requires": {}
     },
     "agent-base": {
@@ -11761,6 +11819,16 @@
           "dev": true
         }
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+    },
+    "dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -13804,8 +13872,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/examples/multiple-queues/package.json
+++ b/examples/multiple-queues/package.json
@@ -22,9 +22,10 @@
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",
+    "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
-    "agenda-nest": "file:../../agenda-nest-1.0.1.tgz",
+    "agenda-nest": "file:../../agenda-nest-1.2.1.tgz",
     "mongodb": "^4.7.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/examples/multiple-queues/src/app.module.ts
+++ b/examples/multiple-queues/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { AgendaModule } from 'agenda-nest';
 import { MongoClient, Db } from 'mongodb';
 import { NotificationsModule } from './notifications/notifications.module';
@@ -7,12 +8,9 @@ import { ReportsModule } from './reports/reports.module';
 const databaseProvider = {
   provide: 'DATABASE_CONNECTION',
   useFactory: async () => {
-    console.log('here');
     const client = new MongoClient('mongodb://localhost:27017');
-    console.log('connecting');
-    await client.connect();
 
-    console.log('connected');
+    await client.connect();
 
     return client.db();
   },
@@ -20,6 +18,7 @@ const databaseProvider = {
 
 @Module({
   imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
     AgendaModule.forRootAsync({
       useFactory: (mongo: Db) => ({
         mongo,

--- a/examples/multiple-queues/src/reports/reports.module.ts
+++ b/examples/multiple-queues/src/reports/reports.module.ts
@@ -1,10 +1,20 @@
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { AgendaModule } from 'agenda-nest';
 import { ReportsQueue } from './reports.queue';
 
 @Module({
   imports: [
-    AgendaModule.registerQueue('reports'),
+    AgendaModule.registerQueueAsync('reports', {
+      useFactory: (config: ConfigService) => {
+        const autoStart = config.get<string>('AUTO_START_QUEUE');
+
+        return {
+          autoStart: autoStart === 'true',
+        };
+      },
+      inject: [ConfigService]
+    }),
   ],
   providers: [ReportsQueue],
 })


### PR DESCRIPTION
This adds support for asynchronous queue registration with the introduction of the static `registerQueueAsync` method. The method accepts the queue name and `AgendaModuleAsyncConfig` so that a queue can be configured using the idiomatic `useExisting`, `useClass`, and `useFactory` methods.