### PR TITLE
Update agenda dependency to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nestjs/common": "8.x || 9.x",
     "@nestjs/core": "8.x || 9.x",
-    "agenda": "4.x"
+    "agenda": "5.x"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",


### PR DESCRIPTION
There is the new v5 agenda version, the only breaking change is it drops support for mongodb < 4.0